### PR TITLE
Mobile friendlier cover layout

### DIFF
--- a/cover.html
+++ b/cover.html
@@ -8,14 +8,6 @@
 		<!-- CSS FILES -->
 		<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.2.0/css/uikit.min.css">
 		<style>
-			.wrap::before {
-				position: absolute;
-				height: 100%;
-				width: 100%;
-				content: '';
-				z-index: 1;
-				background-color: rgba(0,0,0,0.5);
-			}
 			.lead {
 				font-size: 1.175em;
 				font-weight: 300;

--- a/cover.html
+++ b/cover.html
@@ -8,14 +8,6 @@
 		<!-- CSS FILES -->
 		<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.2.0/css/uikit.min.css">
 		<style>
-      .wrap::before {	
-				position: absolute;	
-				height: 100%;	
-				width: 100%;	
-				content: '';	
-				z-index: 1;	
-				background-color: rgba(0,0,0,0.5);	
-			}
 			.lead {
 				font-size: 1.175em;
 				font-weight: 300;
@@ -34,7 +26,7 @@
            sizes="100vw"
            data-src="https://picsum.photos/1200/900/?image=482" alt="" data-uk-cover data-uk-img
       >
-      <div class="uk-flex uk-flex-center uk-flex-middle uk-height-viewport uk-position-z-index uk-position-relative" data-uk-height-viewport="min-height: 400">
+      <div class="uk-flex uk-flex-center uk-flex-middle uk-height-viewport uk-position-z-index uk-position-relative" data-uk-height-viewport="min-height: 400" style="background-color: rgba(0, 0, 0, 0.5);">
 
         <!-- NAV -->
         <div class="uk-position-top">

--- a/cover.html
+++ b/cover.html
@@ -10,8 +10,8 @@
 		<style>
 			.wrap::before {
 				position: absolute;
-				height: 100vh;
-				width: 100vw;
+				height: 100%;
+				width: 100%;
 				content: '';
 				z-index: 1;
 				background-color: rgba(0,0,0,0.5);
@@ -25,56 +25,58 @@
 			}
 		</style>
 	</head>
-	<body class="uk-light wrap uk-background-norepeat uk-background-cover uk-background-center-center uk-cover-container uk-background-secondary">
-		<img data-srcset="https://picsum.photos/640/700/?image=482 640w,
-		             https://picsum.photos/960/700/?image=482 960w,
-		             https://picsum.photos/1200/900/?image=482 1200w,
-		             https://picsum.photos/2000/1000/?image=482 2000w"
-		     sizes="100vw"
-		     data-src="https://picsum.photos/1200/900/?image=482" alt="" data-uk-cover data-uk-img
-		>
-		<div class="uk-flex uk-flex-center uk-flex-middle uk-height-viewport uk-position-z-index uk-position-relative" data-uk-height-viewport="min-height: 400">
-			
-			<!-- NAV -->
-			<div class="uk-position-top">
-				<div class="uk-container uk-container-small">
-					<nav class="uk-navbar-container uk-navbar-transparent" data-uk-navbar>
-						<div class="uk-navbar-left">
-							<div class="uk-navbar-item">
-								<a class="uk-logo" href=""><img src="img/cover-logo.svg" alt="Logo"></a>
-							</div>
-						</div>
-						<div class="uk-navbar-right">
-							<ul class="uk-navbar-nav">
-								<li class="uk-active uk-visible@m"><a href="" data-uk-icon="home"></a></li>
-								<li class="uk-visible@s"><a href="">Features</a></li>
-								<li class="uk-visible@s"><a href="">Security</a></li>
-								<li class="uk-visible@s"><a href="">Testimonials</a></li>
-								<li><a class="uk-navbar-toggle" data-uk-toggle data-uk-navbar-toggle-icon href="#offcanvas-nav"></a></li>
-							</ul>
-						</div>
-					</nav>
-				</div>
-			</div>
-			<!-- /NAV -->
-			<!-- TEXT -->
-			<div class="uk-container uk-container-small uk-flex-auto uk-text-center" data-uk-scrollspy="target: > .animate; cls: uk-animation-slide-bottom-small uk-invisible; delay: 300">
-				<h1 class="uk-heading-primary animate uk-invisible" style="font-weight: 700;">Sleek, Fast and Reliable.</h1>
-				<div class="uk-width-4-5@m uk-margin-auto animate uk-invisible">
-					<p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. A ad, reiciendis maxime, facilis nam natus incidunt provident.</p>
-				</div>
-				<div class="uk-margin-medium-top animate uk-invisible" data-uk-margin data-uk-scrollspy-class="uk-animation-fade uk-invisible">
-					<a class="uk-button uk-button-default uk-button-large uk-width-2-3 uk-width-auto@s" data-uk-icon="arrow-right" title="Learn More">LEARN MORE</a>
-					<a class="uk-button uk-button-primary uk-button-large uk-width-2-3 uk-width-auto@s" data-uk-icon="check" title="Learn More">TRY IT OUT</a>
-				</div>
-			</div>
-			<!-- /TEXT -->
-			<!-- FOOT -->
-			<div class="uk-position-bottom-center uk-position-small">
-				<span class="uk-text-small uk-text-center">© 2019 | <a href="https://github.com/zzseba78/Kick-Off" title="Created by KickOff">Created by KickOff</a> | Built with <a href="http://getuikit.com" title="Visit UIkit 3 site" target="_blank" data-uk-tooltip><span data-uk-icon="uikit"></span></a></span>
-			</div>
-			<!-- /FOOT -->
-		</div>
+	<body>
+    <div>
+      <img data-srcset="https://picsum.photos/640/700/?image=482 640w,
+                   https://picsum.photos/960/700/?image=482 960w,
+                   https://picsum.photos/1200/900/?image=482 1200w,
+                   https://picsum.photos/2000/1000/?image=482 2000w"
+           sizes="100vw"
+           data-src="https://picsum.photos/1200/900/?image=482" alt="" data-uk-cover data-uk-img
+      >
+      <div class="uk-flex uk-flex-center uk-flex-middle uk-height-viewport uk-position-z-index uk-position-relative" data-uk-height-viewport="min-height: 400">
+
+        <!-- NAV -->
+        <div class="uk-position-top">
+          <div class="uk-container uk-container-small">
+            <nav class="uk-navbar-container uk-navbar-transparent" data-uk-navbar>
+              <div class="uk-navbar-left">
+                <div class="uk-navbar-item">
+                  <a class="uk-logo" href=""><img src="img/cover-logo.svg" alt="Logo"></a>
+                </div>
+              </div>
+              <div class="uk-navbar-right">
+                <ul class="uk-navbar-nav">
+                  <li class="uk-active uk-visible@m"><a href="" data-uk-icon="home"></a></li>
+                  <li class="uk-visible@s"><a href="">Features</a></li>
+                  <li class="uk-visible@s"><a href="">Security</a></li>
+                  <li class="uk-visible@s"><a href="">Testimonials</a></li>
+                  <li><a class="uk-navbar-toggle" data-uk-toggle data-uk-navbar-toggle-icon href="#offcanvas-nav"></a></li>
+                </ul>
+              </div>
+            </nav>
+          </div>
+        </div>
+        <!-- /NAV -->
+        <!-- TEXT -->
+        <div class="uk-container uk-container-small uk-flex-auto uk-text-center" data-uk-scrollspy="target: > .animate; cls: uk-animation-slide-bottom-small uk-invisible; delay: 300">
+          <h1 class="uk-heading-primary animate uk-invisible" style="font-weight: 700;">Sleek, Fast and Reliable.</h1>
+          <div class="uk-width-4-5@m uk-margin-auto animate uk-invisible">
+            <p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. A ad, reiciendis maxime, facilis nam natus incidunt provident.</p>
+          </div>
+          <div class="uk-margin-medium-top animate uk-invisible" data-uk-margin data-uk-scrollspy-class="uk-animation-fade uk-invisible">
+            <a class="uk-button uk-button-default uk-button-large uk-width-2-3 uk-width-auto@s" data-uk-icon="arrow-right" title="Learn More">LEARN MORE</a>
+            <a class="uk-button uk-button-primary uk-button-large uk-width-2-3 uk-width-auto@s" data-uk-icon="check" title="Learn More">TRY IT OUT</a>
+          </div>
+        </div>
+        <!-- /TEXT -->
+        <!-- FOOT -->
+        <div class="uk-position-bottom-center uk-position-small">
+          <span class="uk-text-small uk-text-center">© 2019 | <a href="https://github.com/zzseba78/Kick-Off" title="Created by KickOff">Created by KickOff</a> | Built with <a href="http://getuikit.com" title="Visit UIkit 3 site" target="_blank" data-uk-tooltip><span data-uk-icon="uikit"></span></a></span>
+        </div>
+        <!-- /FOOT -->
+      </div>
+    </div>
 		<!-- OFFCANVAS -->
 		<div id="offcanvas-nav" data-uk-offcanvas="flip: true; overlay: false">
 			<div class="uk-offcanvas-bar uk-offcanvas-bar-animation uk-offcanvas-slide">

--- a/cover.html
+++ b/cover.html
@@ -8,6 +8,14 @@
 		<!-- CSS FILES -->
 		<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.2.0/css/uikit.min.css">
 		<style>
+      .wrap::before {	
+				position: absolute;	
+				height: 100%;	
+				width: 100%;	
+				content: '';	
+				z-index: 1;	
+				background-color: rgba(0,0,0,0.5);	
+			}
 			.lead {
 				font-size: 1.175em;
 				font-weight: 300;

--- a/cover.html
+++ b/cover.html
@@ -18,7 +18,7 @@
 		</style>
 	</head>
 	<body>
-    <div>
+    <div class="uk-light wrap uk-background-norepeat uk-background-cover uk-background-center-center uk-cover-container uk-background-secondary">
       <img data-srcset="https://picsum.photos/640/700/?image=482 640w,
                    https://picsum.photos/960/700/?image=482 960w,
                    https://picsum.photos/1200/900/?image=482 1200w,


### PR DESCRIPTION
Hi there.

Using the cover.html layout, Google Search Console started warning me the page was not mobile-friendly. I used their recommended tool at https://search.google.com/test/mobile-friendly to correct it.

This is how it saw the page before:
![download1](https://user-images.githubusercontent.com/170220/67794926-4569af00-fa5c-11e9-8839-49042b2297e6.png)

Changing the body classes into a new parent div made a lot of difference there, but i setill got a "content too wide"error.
![download2](https://user-images.githubusercontent.com/170220/67795091-84980000-fa5c-11e9-8ba4-2e887ec80a78.png)

The .wrapper:before css was at fault on this one. Changing from vh/vw to % didnt help, so i put the background color as an inline style on the appropriate div.
![download3](https://user-images.githubusercontent.com/170220/67795218-ae512700-fa5c-11e9-8ce8-8db04d6e53f2.png)

Aaaaand now it's all green.
![download4](https://user-images.githubusercontent.com/170220/67795350-e35d7980-fa5c-11e9-8f9f-a717d422e0c7.png)

you can check the test out at: https://search.google.com/test/mobile-friendly?url=https%3A%2F%2Fbronze.github.io%2FKick-Off%2Fcover.html

cheers!